### PR TITLE
S3 snapshot async

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -79,7 +79,7 @@ let handlers = {
     },
 
     /**
-     * Statt AWS Batch Job
+     * Start AWS Batch Job
      * starts an aws batch job
      * returns no return. Batch job start is happening after response has been send to client
      */

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -53,7 +53,7 @@ let handlers = {
 
     /**
      * Submit Job
-     * Inserts a job document in mongo and starts snapshot upload
+     * Inserts a job document into mongo and starts snapshot upload
      * returns job to client
      */
     submitJob(req, res) {
@@ -70,8 +70,6 @@ let handlers = {
 
         c.crn.jobs.insertOne(job, (err, mongoJob) => {
             scitran.downloadSymlinkDataset(job.snapshotId, (err, hash) => {
-                console.log("!!!!!!!!!!!!!!!!!!!!!!!!!");
-                console.log(err);
                 aws.s3.uploadSnapshot(hash, () => {
                     handlers.startBatchJob(batchJobParams, mongoJob.insertedId);
                 });
@@ -80,12 +78,16 @@ let handlers = {
         });
     },
 
+    /**
+     * Statt AWS Batch Job
+     * starts an aws batch job
+     * returns no return. Batch job start is happening after response has been send to client
+     */
     startBatchJob(params, jobId) {
         aws.batch.sdk.submitJob(params, (err, data) => {
            //update mongo job with aws batch job id?
            c.crn.jobs.updateOne({_id: jobId}, {$set:{awsBatchJobId: data.jobId, uploadSnapshotComplete: true}}, (err, doc) => {
             //error handling???
-            console.log(doc);
            });
         });
     }


### PR DESCRIPTION
* Create a job document to track AWS batch jobs
* Send response to client once mongo document has been created and start snapshot upload. This should eliminate client side timeouts while waiting for large dataset uploads.
* OPEN ISSUES/QUESTIONS: what should we send back to client other than mongo id on job doc creation? How are we going to track job status and how do we handle errors after we have responded to client?