### PR TITLE
Prevent duplicate analysis jobs and add retry stub

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -99,10 +99,9 @@ let handlers = {
             job.datasetHash = hash;
             job.parametersHash = crypto.createHash('md5').update(JSON.stringify(job.parameters)).digest('hex');
 
-            // Since AWS job def labels have to be unique strings, use that instead of an appId
-            // TODO - Also select on job definition version
+            // jobDefintion is the full ARN including version, region, etc
             c.crn.jobs.findOne({
-                appLabel:       job.appLabel,
+                jobDefinition:  job.jobDefintion,
                 datasetHash:    job.datasetHash,
                 parametersHash: job.parametersHash,
                 snapshotId:     job.snapshotId

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -2,6 +2,8 @@
 
 import aws     from '../libs/aws';
 import scitran from '../libs/scitran';
+import crypto  from 'crypto';
+import uuid    from 'uuid';
 import mongo         from '../libs/mongo';
 import {ObjectID}    from 'mongodb';
 

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -219,6 +219,17 @@ let handlers = {
                 });
             }
         });
+    },
+
+    /**
+     * Retry a job using existing parameters
+     */
+    retry (req, res, next) {
+        // let jobId = req.params.jobId;
+        // TODO - This is a stub for testing - need to resubmit using the same CRN job data but a new AWS Batch job
+        let error = new Error('Retry is not yet supported.');
+        error.http_code = 409;
+        return next(error);
     }
 
 };

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -118,7 +118,7 @@ let handlers = {
                     return;
                 }
 
-                c.crn.jobs.insertOne(job, (err, mongoJob) => {
+                c.crn.jobs.insertOne(job, () => {
 
                     // Finish the client request so S3 upload can happen async
                     res.send({jobId: job.analysis.analysisId});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "nodemailer": "^2.5.0",
     "request": "^2.63.0",
     "tar-fs": "^1.9.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "2.7.0",


### PR DESCRIPTION
This reworks submitJob to properly inform the frontend if an identical analysis has already been run successfully. To do that, a UUID for a particular analysis is created and there's a new "uploading" status for jobs waiting on S3. A job is now only added to the crn database if a similar one does not exist.

The job id returned from AWS is stored as analysis.jobId for now. To support one job per subject parameter, this should be extended to store a job id for each submitted AWS job.

The retry implementation is just a stub, for now it always returns an error.