### PR TITLE
Multi Participant Job Processing

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -81,7 +81,13 @@ let handlers = {
             jobDefinition: job.jobDefinition,
             jobName:       job.jobName,
             jobQueue:      'bids-queue',
-            parameters:    job.parameters
+            parameters:    job.parameters,
+            containerOverrides:{
+                environment: [{
+                    name: 'BIDS_SNAPSHOT_ID',
+                    value: '24fd3a7f24ce267eb488ec5afe5c98c1' || job.snapshotId
+                }]
+            }
         };
 
         job.uploadSnapshotComplete = !!job.uploadSnapshotComplete;
@@ -139,6 +145,7 @@ let handlers = {
      * returns no return. Batch job start is happening after response has been send to client
      */
     startBatchJob(params, jobId) {
+        
         aws.batch.sdk.submitJob(params, (err, data) => {
             //update mongo job with aws batch job id?
             c.crn.jobs.updateOne({_id: jobId}, {
@@ -180,7 +187,7 @@ let handlers = {
                     if(analysis.status === 'SUCCEEDED' || analysis.status === 'FAILED'){
                         let params = {
                             Bucket: 'openneuro.outputs',
-                            Prefix: '24fd3a7f24ce267eb488ec5afe5c98c1'
+                            Prefix: '24fd3a7f24ce267eb488ec5afe5c98c1' || job.snapshotId
                         };
                         aws.s3.sdk.listObjectsV2(params, (err, data) => {
                             let results = [];
@@ -200,7 +207,7 @@ let handlers = {
                     }
                     res.send({
                         analysis: analysis,
-                        jobId: jobId,
+                        jobId: analysisId,
                         datasetId: job.datasetId,
                         snapshotId: job.snapshotId
                     });

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -6,6 +6,7 @@ import crypto  from 'crypto';
 import uuid    from 'uuid';
 import mongo         from '../libs/mongo';
 import {ObjectID}    from 'mongodb';
+import async    from 'async';
 
 let c = mongo.collections;
 
@@ -145,7 +146,7 @@ let handlers = {
      * returns no return. Batch job start is happening after response has been send to client
      */
     startBatchJob(params, jobId) {
-        
+        //check for subject list and make decision regarding job execution (i.e. one job or multiple, parallel jobs)
         aws.batch.sdk.submitJob(params, (err, data) => {
             //update mongo job with aws batch job id?
             c.crn.jobs.updateOne({_id: jobId}, {
@@ -162,6 +163,24 @@ let handlers = {
             //error handling???
             });
         });
+    },
+
+    submitParallelJobs(jobParams, callback) {
+        let job = (params, cb) => {
+            aws.batch.sdk.submitJob(params, cb)
+        };
+
+        let jobs = [];
+
+        jobParams.subjectList.forEach((subject) => {
+            let subjectParams = jobParams; //need to figure out how to make params specific to a subject. specifically env var overrides
+            jobs.push(job.bind(this, subjectParams));
+        });
+        async.parallel(jobs, callback);
+    },
+
+    submitSingleJob(params, callback) {
+        aws.batch.sdk.submitJob(params, callback);
     },
 
         /**

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -147,27 +147,40 @@ let handlers = {
      */
     startBatchJob(params, jobId) {
         //check for subject list and make decision regarding job execution (i.e. one job or multiple, parallel jobs)
-        aws.batch.sdk.submitJob(params, (err, data) => {
-            //update mongo job with aws batch job id?
-            c.crn.jobs.updateOne({_id: jobId}, {
-                $set:{
-                    // jobId: data.jobId,
-                    analysis:{
-                        status: 'PENDING', //setting status to pending as soon as job submissions is successful
-                        attempts: 1,
-                        jobs: data.jobId // Should be an array of AWS ids for each AWS batch job
-                    },
-                    uploadSnapshotComplete: true
-                }
-            }, () => {
-            //error handling???
+        if(params.subjectList) {
+            handlers.submitParallelJobs(params, (err, data) => {
+                handlers.updateJobOnSubmitSuccessful(jobId, data);
             });
+        } else {
+            handlers.submitSingleJob(params, (err, data) => {
+                handlers.updateJobOnSubmitSuccessful(jobId, data);
+            });
+        }
+    },
+
+    updateJobOnSubmitSuccessful(jobId, batchIds) {
+        c.crn.jobs.updateOne({_id: jobId}, {
+            $set:{
+                analysis:{
+                    status: 'PENDING', //setting status to pending as soon as job submissions is successful
+                    attempts: 1,
+                    jobs: batchIds // Should be an array of AWS ids for each AWS batch job
+                },
+                uploadSnapshotComplete: true
+            }
+        }, () => {
+        //error handling???
         });
     },
 
     submitParallelJobs(jobParams, callback) {
         let job = (params, cb) => {
-            aws.batch.sdk.submitJob(params, cb)
+            aws.batch.sdk.submitJob(params, (err, data) => {
+                if(err) {cb(err);}
+                //pass the AWS bactch job ID
+                let jobId = data.jobId;
+                cb(null, jobId);
+            });
         };
 
         let jobs = [];
@@ -180,7 +193,10 @@ let handlers = {
     },
 
     submitSingleJob(params, callback) {
-        aws.batch.sdk.submitJob(params, callback);
+        aws.batch.sdk.submitJob(params, (err, data) => {
+            if(err) {cb(err);}
+            callback(null, [data.jobId]); //storing jobId's as array in mongo to support multi job analysis
+        });
     },
 
         /**
@@ -192,13 +208,14 @@ let handlers = {
         c.crn.jobs.findOne({_id: ObjectID(jobId)}, {}, (err, job) => {
             let status = job.analysis.status;
             let analysisId = job.analysis.analysisId;
+            let jobs = job.analysis.jobs;
             // check if job is already known to be completed
             // there could be a scenario where we are polling before the AWS batch job has been setup. !analysisId check handles this.
-            if ((status === 'SUCCEEDED' && job.results && job.results.length > 0) || status === 'FAILED' || !analysisId) {
+            if ((status === 'SUCCEEDED' && job.results && job.results.length > 0) || status === 'FAILED' || !jobs) {
                 res.send(job);
             } else {
                 let params = {
-                    jobs: [analysisId]
+                    jobs: jobs
                 };
                 aws.batch.sdk.describeJobs(params, (err, resp) => {
                     let analysis = resp.jobs[0];


### PR DESCRIPTION
NOT READY FOR MERGE

Adding ability to spin up multiple parallel jobs for definitions that include a subjectList parameter.
Updating getJob to handle describeJobs responses with multiple jobs from Batch.