### PR TITLE
Download and Zip up job results on s3

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -183,13 +183,13 @@ let handlers = {
                     if(finished){
                         //Check if any jobs failed, if so analysis failed, else succeeded
                         let finalStatus = statusArray.some((status)=>{ return status === 'FAILED';}) ? 'FAILED' : 'SUCCEEDED';
+                        let s3Prefix = job.datasetHash + '/' + job.analysis.analysisId + '/';
                         let params = {
                             Bucket: 'openneuro.outputs',
-                            Prefix: job.datasetHash + '/' + job.analysis.analysisId
+                            Prefix: s3Prefix,
+                            StartAfter: s3Prefix
                         };
-                        console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-                        console.log(params.Prefix);
-                        console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+
                         aws.s3.sdk.listObjectsV2(params, (err, data) => {
                             let results = [];
                             data.Contents.forEach((obj) => {
@@ -215,45 +215,6 @@ let handlers = {
 
                     // notifications.jobComplete(job);
 
-                    // if (resp.body.status === 'error' && resp.body.message.indexOf('No job found with job id') > -1) {
-                    //     job.agave.status = 'FAILED';
-                    //     c.crn.jobs.updateOne({jobId}, {$set: {agave: job.agave}}, {}, () => {
-                    //         res.send({agave: resp.body.result, snapshotId: job.snapshotId});
-                    //         notifications.jobComplete(job);
-                    //     });
-                    // } else if (resp.body && resp.body.result && (resp.body.result.status === 'FINISHED' || resp.body.result.status === 'FAILED')) {
-                    //     job.agave = resp.body.result;
-                    //     agave.getOutputs(jobId, (results, logs) => {
-                    //         c.crn.jobs.updateOne({jobId}, {$set: {agave: resp.body.result, results, logs}}, {}, (err) => {
-                    //             if (err) {res.send(err);}
-                    //             else {res.send({agave: resp.body.result, results, logs, snapshotId: job.snapshotId});}
-                    //             job.agave = resp.body.result;
-                    //             job.results = results;
-                    //             job.logs = logs;
-                    //             if (status !== 'FINISHED') {notifications.jobComplete(job);}
-                    //         });
-                    //     });
-                    // } else if (resp.body && resp.body.result && job.agave.status !== resp.body.result.status) {
-                    //     job.agave = resp.body.result;
-                    //     c.crn.jobs.updateOne({jobId}, {$set: {agave: resp.body.result}}, {}, (err) => {
-                    //         if (err) {res.send(err);}
-                    //         else {
-                    //             res.send({
-                    //                 agave:      resp.body.result,
-                    //                 datasetId:  job.datasetId,
-                    //                 snapshotId: job.snapshotId,
-                    //                 jobId:      jobId
-                    //             });
-                    //         }
-                    //     });
-                    // } else {
-                    //     res.send({
-                    //         agave:      resp.body.result,
-                    //         datasetId:  job.datasetId,
-                    //         snapshotId: job.snapshotId,
-                    //         jobId:      jobId
-                    //     });
-                    // }
                 });
             }
         });
@@ -282,11 +243,13 @@ let handlers = {
             });
 
             c.crn.jobs.findOne({_id: ObjectID(jobId)}, {}, (err, job) => {
-                let archiveName = job.datasetLabel + '__' + job.appId + '__' + type;
+                let archiveName = job.datasetLabel + '__' + job.analysis.analysisId + '__' + type;
+                let s3Prefix = job.datasetHash + '/' + job.analysis.analysisId + '/';
                 //params to list objects for a job
                 let params = {
                     Bucket: config.aws.s3.analysisBucket,
-                    Prefix: job.datasetHash + job.analysis.analysisId
+                    Prefix: s3Prefix,
+                    StartAfter: s3Prefix
                 };
 
                 // set archive name
@@ -297,8 +260,6 @@ let handlers = {
 
                 aws.s3.sdk.listObjectsV2(params, (err, data) => {
                     let keysArray = [];
-                    console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-                    console.log(data);
                     data.Contents.forEach((obj) => {
                         keysArray.push(obj.Key);
                     });
@@ -308,22 +269,16 @@ let handlers = {
                             Bucket: config.aws.s3.analysisBucket,
                             Key: key
                         };
+                        let fileName = key.split('/')[key.split('/').length - 1]; //get filename from key
                         aws.s3.sdk.getObject(objParams, (err, response) => {
                             //append to zip
-                            console.log(response);
-                            console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-                            archive.append(response.Body, {name: 'test.txt'});
+                            archive.append(response.Body, {name: fileName});
                             cb();
                         });
                     }, () => {
                         archive.finalize();
                     });
                 });
-
-                // recurse outputs
-                // getOutputs(archiveName, job[type], type, archive, () => {
-                //     archive.finalize();
-                // });
             });
         }
 

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -287,19 +287,31 @@ let handlers = {
                 // begin streaming archive
                 archive.pipe(res);
 
-                aws.s3.listObjectsV2(params, (err, data) {
+                aws.s3.listObjectsV2(params, (err, data) => {
                     let keysArray = [];
                     data.Contents.forEach((obj) => {
                         keysArray.push(obj.Key;
-
                     });
-                    
+
+                    async.eachSeries(keysArray, (key, cb) => {
+                        let objParams = {
+                            Bucket: 'openneuro.outputs',
+                            Key: key
+                        };
+                        aws.s3.getObject(objParams, (err, response) => {
+                            //append to zip
+                            archive.append(res.body, {name: 'test.txt'});
+                            cb();
+                        });
+                    }, () => {
+                        archive.finalize();
+                    });
                 });
 
                 // recurse outputs
-                getOutputs(archiveName, job[type], type, archive, () => {
-                    archive.finalize();
-                });
+                // getOutputs(archiveName, job[type], type, archive, () => {
+                //     archive.finalize();
+                // });
             });
 
         }

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -1,3 +1,4 @@
+/*eslint no-console: ["error", { allow: ["log"] }] */
 // dependencies ------------------------------------------------------------
 
 import aws     from '../libs/aws';
@@ -8,7 +9,7 @@ import mongo         from '../libs/mongo';
 import {ObjectID}    from 'mongodb';
 import archiver      from 'archiver';
 import config from '../config';
-import async from 'async'
+import async from 'async';
 
 let c = mongo.collections;
 

--- a/handlers/jobs.js
+++ b/handlers/jobs.js
@@ -316,49 +316,18 @@ let handlers = {
     /**
      * GET Download Ticket
      */
-    getDownloadTicket(req, res, next) {
-            // form ticket
-            let ticket = {
-                type: 'download',
-                userId: req.user,
-                jobId: jobId,
-                fileName: 'all',
-                filePath: filePath,
-                created: new Date()
-            };
+    getDownloadTicket(req, res) {
+        let jobId = req.params.jobId;
+        // form ticket
+        let ticket = {
+            type: 'download',
+            userId: req.user,
+            jobId: jobId,
+            fileName: 'all',
+            created: new Date()
+        };
 
-            res.send(ticket);
-/*
-        let jobId    = req.params.jobId,
-            filePath = req.query.filePath,
-            fileName = filePath.split('/')[filePath.split('/').length - 1];
-        c.crn.jobs.findOne({jobId}, {}, (err, job) => {
-            // check for job
-            if (err){return next(err);}
-            if (!job) {
-                let error = new Error('Could not find job.');
-                error.http_code = 404;
-                return next(error);
-            }
-
-            // form ticket
-            let ticket = {
-                type: 'download',
-                userId: req.user,
-                jobId: jobId,
-                fileName: fileName,
-                filePath: filePath,
-                created: new Date()
-            };
-
-            // Create and return ticket
-            c.crn.tickets.insertOne(ticket, (err) => {
-                if (err) {return next(err);}
-                c.crn.tickets.ensureIndex({created: 1}, {expireAfterSeconds: 60 * 60}, () => {
-                    res.send(ticket);
-                });
-            });
-        });*/
+        res.send(ticket);
     },
 
     /**

--- a/handlers/jobs.js
+++ b/handlers/jobs.js
@@ -317,6 +317,18 @@ let handlers = {
      * GET Download Ticket
      */
     getDownloadTicket(req, res, next) {
+            // form ticket
+            let ticket = {
+                type: 'download',
+                userId: req.user,
+                jobId: jobId,
+                fileName: 'all',
+                filePath: filePath,
+                created: new Date()
+            };
+
+            res.send(ticket);
+/*
         let jobId    = req.params.jobId,
             filePath = req.query.filePath,
             fileName = filePath.split('/')[filePath.split('/').length - 1];
@@ -346,7 +358,7 @@ let handlers = {
                     res.send(ticket);
                 });
             });
-        });
+        });*/
     },
 
     /**

--- a/routes.js
+++ b/routes.js
@@ -174,10 +174,10 @@ const routes = [
     {
         method: 'get',
         url: '/jobs/:jobId/results/:fileName',
-        middleware: [
-            auth.ticket
-        ],
-        handler: jobs.downloadAllS3
+        // middleware: [
+        //     auth.ticket
+        // ],
+        handler: awsJobs.downloadAllS3
     }
 
 ];

--- a/routes.js
+++ b/routes.js
@@ -177,7 +177,7 @@ const routes = [
         middleware: [
             auth.ticket
         ],
-        handler: jobs.getFile
+        handler: jobs.downloadAllS3
     }
 
 ];


### PR DESCRIPTION
Grabs all results files from s3 for a given job and zips them up and streams them to the client.  Also, fixed a bug with get job where we were sending back a directory as a "result file" which resulted in a rogue line in the file tree results UI.  This branch goes along with crn_app branch aws-download-all