### PR TITLE
Job Definition Descriptions for AWS Batch Jobs

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -35,9 +35,11 @@ let handlers = {
             } else {
                 let extendeJobDef = data;
                 extendeJobDef.descriptions = req.body.descriptions || {};
-                c.crn.jobDefinitions.insertOne(extendeJobDef, (err, data) => {
-                    //TODO -- error handling? make response dependant on inserting document?
-                })
+                c.crn.jobDefinitions.insertOne(extendeJobDef, (err) => {
+                    if(err){
+                        //TODO -- error handling? make response dependant on inserting document?
+                    }
+                });
                 // can go ahead and respond to client without waiting on mongo insert
                 res.send(data);
             }

--- a/libs/mongo.js
+++ b/libs/mongo.js
@@ -31,6 +31,7 @@ export default {
             blacklist: null,
             validationQueue: null,
             jobs: null,
+            jobDefinitions: null,
             tickets: null,
             userPreferences: null,
             notifications: null,

--- a/schemas/job.js
+++ b/schemas/job.js
@@ -31,7 +31,8 @@ const definition = {
         jobDefinitionName: {type: 'string'},
         containerProperties: {$ref: '#/definitions/containerProperties'},
         parameters: {type: 'object'},
-        type: {type: 'string'}
+        type: {type: 'string'},
+        descriptions: {type: 'object'}
     },
     definitions: {
         containerProperties: {
@@ -87,7 +88,8 @@ const definition = {
         'jobDefinitionName',
         'containerProperties',
         'parameters',
-        'type'
+        'type',
+        'descriptions'
     ],
     additionalProperties: false
 };

--- a/schemas/job.js
+++ b/schemas/job.js
@@ -32,7 +32,8 @@ const definition = {
         containerProperties: {$ref: '#/definitions/containerProperties'},
         parameters: {type: 'object'},
         type: {type: 'string'},
-        descriptions: {type: 'object'}
+        descriptions: {type: 'object'},
+        parametersMetadata: {type: 'object'}
     },
     definitions: {
         containerProperties: {
@@ -89,7 +90,8 @@ const definition = {
         'containerProperties',
         'parameters',
         'type',
-        'descriptions'
+        'descriptions',
+        'parametersMetadata'
     ],
     additionalProperties: false
 };


### PR DESCRIPTION
* partially resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/6. Client side form still needs additional work to support all descriptions that Agave supported.
* adding support for job definition descriptions for AWS Batch jobs.  As Batch does not allow us to store arbitrary data along with the job def, we are making a reference to the job in mongo and storing job definition descriptions there.
* Attaching descriptions to job defs when request is made to GET jobs