### PR TITLE
Filter apps list to only include locally defined apps

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -87,12 +87,14 @@ let handlers = {
                             jobDefinitionName: definition.jobDefinitionName,
                             jobDefinitionArn: definition.jobDefinitionArn,
                             revision: definition.revision
-                        }, {descriptions: true, parametersMetadata: true}).toArray((err, def) => {
+                        }, {descriptions: true, parametersMetadata: true, analysisLevels: true}).toArray((err, def) => {
                             // there will either be a one element array or an empty array returned
                             let descriptions = def.length === 0 || !def[0].descriptions ? {} : def[0].descriptions;
                             let parametersMetadata = def.length === 0 || !def[0].parametersMetadata ? {} : def[0].parametersMetadata;
+                            let analysisLevels = def.length === 0 || !def[0].analysisLevels ? {} : def[0].analysisLevels;
                             definition.descriptions = descriptions;
                             definition.parametersMetadata = parametersMetadata;
+                            definition.analysisLevels = analysisLevels;
                             definitions[definition.jobDefinitionName][definition.revision] = definition;
                             cb();
                         });

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -69,33 +69,38 @@ let handlers = {
      * Describe Job Definitions
      */
     describeJobDefinitions(req, res, next) {
-        aws.batch.sdk.describeJobDefinitions({}, (err, data) => {
-            if (err) {
-                return next(err);
-            } else {
-                let definitions = {};
-                //need to attach job definition descriptions from mongo to job defs returned from AWS batch
-                async.each(data.jobDefinitions, (definition, cb) => {
-                    if (!definitions.hasOwnProperty(definition.jobDefinitionName)) {
-                        definitions[definition.jobDefinitionName] = {};
-                    }
-                    c.crn.jobDefinitions.find({
-                        jobDefinitionName: definition.jobDefinitionName,
-                        jobDefinitionArn: definition.jobDefinitionArn,
-                        revision: definition.revision
-                    }, {descriptions: true, parametersMetadata: true}).toArray((err, def) => {
-                        // there will either be a one element array or an empty array returned
-                        let descriptions = def.length === 0 || !def[0].descriptions ? {} : def[0].descriptions;
-                        let parametersMetadata = def.length === 0 || !def[0].parametersMetadata ? {} : def[0].parametersMetadata;
-                        definition.descriptions = descriptions;
-                        definition.parametersMetadata = parametersMetadata;
-                        definitions[definition.jobDefinitionName][definition.revision] = definition;
-                        cb();
+        c.crn.jobDefinitions.find({}, {jobDefinitionArn: true}).toArray((err, appDefs) => {
+            let arns = appDefs.map((app) => {
+                return app.jobDefinitionArn;
+            });
+            aws.batch.sdk.describeJobDefinitions({jobDefinitions: arns}, (err, data) => {
+                if (err) {
+                    return next(err);
+                } else {
+                    let definitions = {};
+                    //need to attach job definition descriptions from mongo to job defs returned from AWS batch
+                    async.each(data.jobDefinitions, (definition, cb) => {
+                        if (!definitions.hasOwnProperty(definition.jobDefinitionName)) {
+                            definitions[definition.jobDefinitionName] = {};
+                        }
+                        c.crn.jobDefinitions.find({
+                            jobDefinitionName: definition.jobDefinitionName,
+                            jobDefinitionArn: definition.jobDefinitionArn,
+                            revision: definition.revision
+                        }, {descriptions: true, parametersMetadata: true}).toArray((err, def) => {
+                            // there will either be a one element array or an empty array returned
+                            let descriptions = def.length === 0 || !def[0].descriptions ? {} : def[0].descriptions;
+                            let parametersMetadata = def.length === 0 || !def[0].parametersMetadata ? {} : def[0].parametersMetadata;
+                            definition.descriptions = descriptions;
+                            definition.parametersMetadata = parametersMetadata;
+                            definitions[definition.jobDefinitionName][definition.revision] = definition;
+                            cb();
+                        });
+                    }, () => {
+                        res.send(definitions);
                     });
-                }, () => {
-                    res.send(definitions);
-                });
-            }
+                }
+            });
         });
     },
 


### PR DESCRIPTION
This prevents crossover between different installs of OpenNeuro and cleans up the list of available apps.