### PR TITLE
Adding event emitter lib/class for logging purposes

### DIFF
--- a/config.js
+++ b/config.js
@@ -52,6 +52,12 @@ let config = {
             vcpusMax: 4,
             memoryMax: 15360
         }
+    },
+
+    events: {
+        JOB_STARTED: 'job-started',
+        JOB_COMPLETED: 'job-completed',
+        DATASET_UPLOADED: 'dataset-uploaded'
     }
 };
 

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -11,7 +11,10 @@ import archiver      from 'archiver';
 import config from '../config';
 import async from 'async';
 
+import emitter from '../libs/events';
+
 let c = mongo.collections;
+let events = config.events;
 
 // handlers ----------------------------------------------------------------
 
@@ -173,6 +176,7 @@ let handlers = {
                         };
 
                         aws.batch.startBatchJob(batchJobParams, mongoJob.insertedId);
+                        emitter.emit(events.JOB_STARTED, {job: batchJobParams, createdDate: job.analysis.created});
                     });
                 });
             });
@@ -225,6 +229,8 @@ let handlers = {
                             Prefix: s3Prefix,
                             StartAfter: s3Prefix
                         };
+                        // emit a job finished event so we can add logs
+                        emitter.emit(events.JOB_COMPLETED, {job: job, completedDate: new Date()});
 
                         aws.s3.sdk.listObjectsV2(params, (err, data) => {
                             let results = [];

--- a/libs/events.js
+++ b/libs/events.js
@@ -1,0 +1,30 @@
+import {EventEmitter} from 'events';
+import config  from '../config';
+import mongo from './mongo';
+
+let c = mongo.collections;
+
+class CrnEmitter extends EventEmitter {
+    constructor(events){
+        super();
+        if(!CrnEmitter.instance) {
+            CrnEmitter.instance = this;
+        }
+        this.events = events;
+        return CrnEmitter.instance;
+    }
+};
+
+let emitter = new CrnEmitter(config.events);
+
+Object.keys(emitter.events).forEach((event) => {
+    emitter.on(emitter.events[event], (data) => {
+        //update logs collection in mongo
+        c.crn.logs.insert({type: event, data: data});
+    });
+});
+
+Object.freeze(emitter);
+
+export default emitter;
+

--- a/libs/events.js
+++ b/libs/events.js
@@ -13,7 +13,7 @@ class CrnEmitter extends EventEmitter {
         this.events = events;
         return CrnEmitter.instance;
     }
-};
+}
 
 let emitter = new CrnEmitter(config.events);
 

--- a/libs/mongo.js
+++ b/libs/mongo.js
@@ -35,7 +35,8 @@ export default {
             tickets: null,
             userPreferences: null,
             notifications: null,
-            counters: null
+            counters: null,
+            logs: null
         },
         scitran: {
             projects: null,

--- a/server.js
+++ b/server.js
@@ -10,6 +10,9 @@ import bodyParser from 'body-parser';
 import morgan     from 'morgan';
 import mongo      from './libs/mongo';
 
+// import events lib to instantiate CRN Emitter
+import events      from './libs/events';
+
 // configuration ---------------------------------------------------
 
 mongo.connect();


### PR DESCRIPTION
We still need to answer question regarding dataset event.
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/37
* adding an event emitter lib that creates a CrnEmitter singleton instance for use by crn_server repo.
* adding event definitions to config so we can expand the use of this lib in the future if needed.
* adding event emission(?) to the start job and finish job logic in awsJobs.js
