### PR TITLE
Handle errors during job submission with a promise

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -175,7 +175,13 @@ let handlers = {
                             }
                         };
 
-                        aws.batch.startBatchJob(batchJobParams, mongoJob.insertedId);
+                        let jobSubmitted = aws.batch.startBatchJob(batchJobParams, mongoJob.insertedId);
+                        jobSubmitted.then(
+                            () => {},
+                            (err) => {
+                                next(err);
+                            }
+                        );
                     });
                 });
             });

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -37,6 +37,7 @@ let handlers = {
                 return next(err);
             } else {
                 let extendeJobDef = data;
+                extendeJobDef.parameters = req.body.parameters || {};
                 extendeJobDef.descriptions = req.body.descriptions || {};
                 extendeJobDef.parametersMetadata = req.body.parametersMetadata || {};
                 extendeJobDef.analysisLevels = req.body.analysisLevels || {};
@@ -87,11 +88,13 @@ let handlers = {
                             jobDefinitionName: definition.jobDefinitionName,
                             jobDefinitionArn: definition.jobDefinitionArn,
                             revision: definition.revision
-                        }, {descriptions: true, parametersMetadata: true, analysisLevels: true}).toArray((err, def) => {
+                        }, {descriptions: true, parameters: true, parametersMetadata: true, analysisLevels: true}).toArray((err, def) => {
                             // there will either be a one element array or an empty array returned
+                            let parameters = def.length === 0 || !def[0].parameters ? {} : def[0].parameters;
                             let descriptions = def.length === 0 || !def[0].descriptions ? {} : def[0].descriptions;
                             let parametersMetadata = def.length === 0 || !def[0].parametersMetadata ? {} : def[0].parametersMetadata;
                             let analysisLevels = def.length === 0 || !def[0].analysisLevels ? {} : def[0].analysisLevels;
+                            definition.parameters = parameters;
                             definition.descriptions = descriptions;
                             definition.parametersMetadata = parametersMetadata;
                             definition.analysisLevels = analysisLevels;

--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -143,10 +143,17 @@ export default (aws) => {
          * {key: ...value}
          */
         _prepareArguments(parameters) {
-            return Object.keys(parameters).map((key) => {
-                let parameter = parameters[key];
+            return Object.keys(parameters).filter((key) => {
+                // Skip empty arguments
+                let value = parameters[key];
+                if (value instanceof Array) {
+                    return value.length > 0;
+                } else {
+                    return parameters[key];
+                }
+            }).map((key) => {
                 let argument = '--' + key + ' ';
-                let value = parameter || '';
+                let value = parameters[key];
                 if (value instanceof Array) {
                     value = value.join(' ');
                 }

--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -106,18 +106,27 @@ export default (aws) => {
                 });
             };
 
-            let jobs = [];
-
-            batchJob.parameters.participant_label.forEach((subject) => {
-                let subjectBatchJob = JSON.parse(JSON.stringify(batchJob));
-                subjectBatchJob.dependsOn = _depsObjects(deps);
-                // Reduce participant_label to a single subject
-                subjectBatchJob.parameters.participant_label = [subject];
-                this._addJobArguments(subjectBatchJob);
-                delete subjectBatchJob.parameters;
-                jobs.push(job.bind(this, subjectBatchJob));
-            });
-            async.parallel(jobs, callback);
+            if (batchJob.parameters.hasOwnProperty('participant_label') &&
+                batchJob.parameters.participant_label instanceof Array &&
+                batchJob.parameters.participant_label.length > 0) {
+                let jobs = [];
+                console.log(batchJob.parameters.participant_label);
+                batchJob.parameters.participant_label.forEach((subject) => {
+                    let subjectBatchJob = JSON.parse(JSON.stringify(batchJob));
+                    subjectBatchJob.dependsOn = _depsObjects(deps);
+                    // Reduce participant_label to a single subject
+                    subjectBatchJob.parameters.participant_label = [subject];
+                    this._addJobArguments(subjectBatchJob);
+                    delete subjectBatchJob.parameters;
+                    jobs.push(job.bind(this, subjectBatchJob));
+                });
+                async.parallel(jobs, callback);
+            } else {
+                // Parallel job with no participants passed in
+                let err = new Error('Parallel job submitted with no subjects specified');
+                err.http_code = 422;
+                callback(err);
+            }
         },
 
         /**

--- a/tests/libs/aws.spec.js
+++ b/tests/libs/aws.spec.js
@@ -4,6 +4,8 @@ var aws = require('../../libs/aws');
 const subjectParam = {participant_label: ['01', '02', '03']};
 const nCpusParam = {n_cpus: 4};
 const templateNameParam = {template_name: 'template1'};
+const emptyParam = {template_name: []};
+const nullParam = {template_name: null};
 
 describe('libs/aws/batch.js', () => {
     describe('_prepareArguments()', () => {
@@ -24,6 +26,16 @@ describe('libs/aws/batch.js', () => {
         });
         it('should combine multiple arguments', () => {
             let params = Object.assign({}, subjectParam, nCpusParam);
+            let args = aws.batch._prepareArguments(params);
+            assert.equal(args, '--participant_label 01 02 03 --n_cpus 4');
+        });
+        it('should not include empty list parameters', () => {
+            let params = Object.assign({}, subjectParam, nCpusParam, emptyParam);
+            let args = aws.batch._prepareArguments(params);
+            assert.equal(args, '--participant_label 01 02 03 --n_cpus 4');
+        });
+        it('should not include null parameters', () => {
+            let params = Object.assign({}, subjectParam, nCpusParam, nullParam);
             let args = aws.batch._prepareArguments(params);
             assert.equal(args, '--participant_label 01 02 03 --n_cpus 4');
         });


### PR DESCRIPTION
Pulled this last commit out of #74 because it doesn't currently work. A promise seems like a better way to handle returning an error status from far down the call stack, but by the time the promise resolves, headers are already sent.

This PR can probably just be closed, but I thought it would be useful to discuss.