### PR TITLE
Update single batch job submit to clone batch job object

### DIFF
--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -134,11 +134,12 @@ export default (aws) => {
          * callsback with a single element array containing the AWS batch ID.
          */
         submitSingleJob(batchJob, deps, callback) {
-            this._addJobArguments(batchJob);
-            batchJob.dependsOn = _depsObjects(deps);
+            let singleBatchJob = JSON.parse(JSON.stringify(batchJob));
+            this._addJobArguments(singleBatchJob);
+            singleBatchJob.dependsOn = _depsObjects(deps);
             // After constructing the job document, remove invalid object from batch job
-            delete batchJob.parameters;
-            batch.submitJob(batchJob, (err, data) => {
+            delete singleBatchJob.parameters;
+            batch.submitJob(singleBatchJob, (err, data) => {
                 if(err) {callback(err);}
                 callback(null, [data.jobId]); //storing jobId's as array in mongo to support multi job analysis
             });


### PR DESCRIPTION
Single job submit was using the batchJob object without cloning it and then deleting a prop off the object resulting in some unexpected failures.  Want to clone the batch object so we are not messing with the original object passed in.