### PR TITLE
Adding Cloudwatch Job Logs

### DIFF
--- a/config.js
+++ b/config.js
@@ -51,6 +51,9 @@ let config = {
         'batch': {
             vcpusMax: 4,
             memoryMax: 15360
+        },
+        'cloudwatchlogs': {
+            logGroupName: '/aws/batch/job'
         }
     }
 };

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -374,6 +374,7 @@ let handlers = {
                 };
                 logsFunc(params, logs, cb);
             }, (err) =>{
+                if(err) {return next(err);}
                 res.send(logs);
             });
         });

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -336,9 +336,33 @@ let handlers = {
     getJobLogs (req, res, next) {
         let jobId = req.params.jobId; //this will be the mongoId for a given analysis
         let logs = {};
+
+        //Recursive function to snag all logs from a logstream
+        let logsFunc = (params, logs, callback) => {
+            let logStreamName = params.logStreamName;
+            aws.cloudwatch.sdk.getLogEvents(params, (err, data)=> {
+                if(err) {return callback(err);}
+                //Cloudwatch returns a token even if there are no events. That is why checking events length
+                if((data.events && data.events.length > 0) && data.nextForwardToken) {
+                    if(!logs[logStreamName]) {
+                        logs[logStreamName] = [];
+                    }
+                    logs[logStreamName] = logs[logStreamName].concat(data.events);
+                    params.nextToken = data.nextForwardToken;
+                    if(params.startFromHead) {
+                        delete params.startFromHead; //only necessary on first call I think.
+                    }
+                    logsFunc(params, logs, callback);
+                } else {
+                    callback();
+                }
+            });
+        };
+
         c.crn.jobs.findOne({_id: ObjectID(jobId)}, {}, (err, job) => {
             if(err) {next(err);}
             let logStreamNames = job.analysis.logstreams || [];
+            let logs = {};
             //cloudwatch log events requires knowing jobId and taskArn(s)
             // taskArns are available on job which we can access with a describeJobs call to batch
             async.eachSeries(logStreamNames, (logStreamName, cb) => {
@@ -346,12 +370,10 @@ let handlers = {
                 // however there is a bug that will require a little more work to make this happen. https://forums.aws.amazon.com/thread.jspa?threadID=251240&tstart=0
                 let params = {
                     logGroupName: config.aws.cloudwatchlogs.logGroupName,
-                    logStreamName: logStreamName
+                    logStreamName: logStreamName,
+                    startFromHead: true
                 };
-                aws.cloudwatch.sdk.getLogEvents(params, (err, data)=> {
-                    logs[logStreamName] = data;
-                    cb();
-                });
+                logsFunc(params, logs, cb);
             }, (err) =>{
                 res.send(logs);
             });

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -335,7 +335,6 @@ let handlers = {
 
     getJobLogs (req, res, next) {
         let jobId = req.params.jobId; //this will be the mongoId for a given analysis
-        let logs = {};
 
         //Recursive function to snag all logs from a logstream
         let logsFunc = (params, logs, callback) => {

--- a/libs/aws/cloudwatchlogs.js
+++ b/libs/aws/cloudwatchlogs.js
@@ -1,0 +1,15 @@
+/*eslint no-console: ["error", { allow: ["log"] }] */
+import mongo from '../../libs/mongo';
+import async from 'async';
+import config from '../../config';
+
+let c = mongo.collections;
+
+export default (aws) => {
+
+    const cloudwatchlogs = new aws.CloudWatchLogs();
+
+    return {
+        sdk: cloudwatchlogs
+    };
+};

--- a/libs/aws/cloudwatchlogs.js
+++ b/libs/aws/cloudwatchlogs.js
@@ -1,9 +1,4 @@
 /*eslint no-console: ["error", { allow: ["log"] }] */
-import mongo from '../../libs/mongo';
-import async from 'async';
-import config from '../../config';
-
-let c = mongo.collections;
 
 export default (aws) => {
 

--- a/libs/aws/index.js
+++ b/libs/aws/index.js
@@ -2,11 +2,13 @@ import aws    from 'aws-sdk';
 import config from '../../config';
 import batch  from './batch';
 import s3     from './s3';
+import cloudwatch from './cloudwatchlogs';
 
 aws.config.update(config.aws.credentials);
 
 
 export default {
     batch: batch(aws),
-    s3:    s3(aws)
+    s3:    s3(aws),
+    cloudwatch: cloudwatch(aws)
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ajv": "4.9.0",
     "archiver": "^1.0.0",
     "async": "^1.5.0",
-    "aws-sdk": "2.14.0",
+    "aws-sdk": "2.50.0",
     "babel": "^5.8.23",
     "bids-validator": "0.20.0",
     "body-parser": "^1.14.0",

--- a/routes.js
+++ b/routes.js
@@ -178,8 +178,12 @@ const routes = [
         //     auth.ticket
         // ],
         handler: awsJobs.downloadAllS3
+    },
+    {
+        method: 'get',
+        url: '/jobs/:jobId/logs',
+        handler: awsJobs.getJobLogs
     }
-
 ];
 
 // initialize routes -------------------------------


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/44
* adding a call to cloudwatch to grab log events.  
* requires crn_app branch of same name, job-logs