### PR TITLE
Reject job definitions with no analysis levels and return useful errors.

### DIFF
--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -25,7 +25,7 @@ export default (aws) => {
          * Register a job and store some additional metadata with AWS Batch
          */
         registerJobDefinition(jobDef, callback) {
-            let error = this._validateInputs(jobDef)
+            let error = this._validateInputs(jobDef);
             if (error) {
                 return callback(error);
             }


### PR DESCRIPTION
The main change here is to reject an app definition if you have not defined the analysis levels, but I also have the server returning an error message for each kind of validation failure now.