### PR TITLE
Handle cases where the batch job is not submitted due an error from AWS.

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -214,7 +214,7 @@ let handlers = {
 
             // check if job is already known to be completed
             // there could be a scenario where we are polling before the AWS batch job has been setup. !jobs check handles this.
-            if ((status === 'SUCCEEDED' && job.results && job.results.length > 0) || status === 'FAILED' || !jobs) {
+            if ((status === 'SUCCEEDED' && job.results && job.results.length > 0) || status === 'FAILED' || status === 'REJECTED' || !jobs) {
                 res.send(job);
             } else {
                 let params = {

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -183,8 +183,8 @@ let handlers = {
                                 // This is an unexpected error, probably from batch.
                                 console.log(err);
                                 // Cleanup the failed to submit job
-                                // TODO - handle this by not inserting it in the first place?
-                                c.crn.jobs.remove({_id: mongoJob.insertedId}, true);
+                                // TODO - Maybe we save the error message into another field for display?
+                                c.crn.jobs.updateOne({_id: mongoJob.insertedId}, {$set: {'analysis.status': 'REJECTED'}});
                                 return;
                             } else {
                                 emitter.emit(events.JOB_STARTED, {job: batchJobParams, createdDate: job.analysis.created});

--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -45,7 +45,7 @@ export default (aws) => {
          * starts an aws batch job
          * returns no return. Batch job start is happening after response has been send to client
          */
-        startBatchJob(batchJob, jobId) {
+        startBatchJob(batchJob, jobId, callback) {
             c.crn.jobDefinitions.findOne({jobDefinitionArn: batchJob.jobDefinition}, {}, (err, jobDef) => {
                 let analysisLevels = jobDef.analysisLevels;
                 async.reduce(analysisLevels, [], (deps, level, callback) => {
@@ -64,12 +64,21 @@ export default (aws) => {
                         submitter = this.submitSingleJob.bind(this);
                     }
                     submitter(batchJob, deps, (err, batchJobIds) => {
-                        // Submit the next set of jobs including the previous as deps
-                        callback(null, deps.concat(batchJobIds));
+                        if (err) {
+                            return callback(err);
+                        } else {
+                            // Submit the next set of jobs including the previous as deps
+                            return callback(null, deps.concat(batchJobIds));
+                        }
                     });
                 }, (err, batchJobIds) => {
-                    // When all jobs are submitted, update job state with the last set
-                    this._updateJobOnSubmitSuccessful(jobId, batchJobIds);
+                    if (err) {
+                        return callback(err);
+                    } else {
+                        // When all jobs are submitted, update job state with the last set
+                        this._updateJobOnSubmitSuccessful(jobId, batchJobIds);
+                        return callback(null, batchJobIds);
+                    }
                 });
             });
         },
@@ -99,7 +108,9 @@ export default (aws) => {
         submitParallelJobs(batchJob, deps, callback) {
             let job = (params, callback) => {
                 batch.submitJob(params, (err, data) => {
-                    if(err) {callback(err);}
+                    if (err) {
+                        return callback(err);
+                    }
                     //pass the AWS batch job ID
                     let jobId = data.jobId;
                     callback(null, jobId);
@@ -140,7 +151,9 @@ export default (aws) => {
             // After constructing the job document, remove invalid object from batch job
             delete singleBatchJob.parameters;
             batch.submitJob(singleBatchJob, (err, data) => {
-                if(err) {callback(err);}
+                if (err) {
+                    return callback(err);
+                }
                 callback(null, [data.jobId]); //storing jobId's as array in mongo to support multi job analysis
             });
         },


### PR DESCRIPTION
Adds an error callback to startBatchJob and passes those errors back through the required callbacks. The batch error should be logged to the console.