### PR TITLE
Preserve folder structure when returning job results

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -273,7 +273,7 @@ let handlers = {
                                     results.push(result);
                                 }
                             });
-///////////////////this could use some cleanup but works fro now//////////////////////
+                            //Need to format results to preserver folder structure. this could use some cleanup but works for now
                             let formattedResults = [];
                             let resultStore = {};
 
@@ -348,7 +348,7 @@ let handlers = {
                             Object.keys(resultStore).forEach((result) => {
                                 formattedResults.push(resultStore[result]);
                             });
-///////////////////////////////////////////////////////////////////////////////////////////
+                            //update job with status, results and logstreams
                             c.crn.jobs.updateOne({_id: ObjectID(jobId)}, {
                                 $set:{
                                     'analysis.status': finalStatus,

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -430,7 +430,7 @@ let handlers = {
                             Bucket: config.aws.s3.analysisBucket,
                             Key: key
                         };
-                        let fileName = key.split('/')[key.split('/').length - 1]; //get filename from key
+                        let fileName = key.split('/').slice(2).join('/');
                         aws.s3.sdk.getObject(objParams, (err, response) => {
                             //append to zip
                             archive.append(response.Body, {name: fileName});

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -273,10 +273,85 @@ let handlers = {
                                     results.push(result);
                                 }
                             });
+///////////////////this could use some cleanup but works fro now//////////////////////
+                            let formattedResults = [];
+                            let resultStore = {};
+
+
+                            let nestResultsByPath = (array, store) => {
+                                let parent = store[array[0]];
+                                let path = parent.dirPath;
+
+                                let checkChildren = (childrenArray, path) => {
+                                    return childrenArray.find((child) => {
+                                        return child.dirPath === path;
+                                    });
+                                }
+
+                                array.forEach((level, k) => {
+                                    //right now setting up top level before passing in store. can probably change this
+                                    if(k === 0) {
+                                        parent._id = k;
+                                        parent.name = level;
+                                        return;
+                                    }
+
+                                    path = path + level + (k === array.length-1 ? '': '/'); //last element in array is the filename
+
+                                    let child = checkChildren(parent.children, path);
+                                    if(child) {
+                                        parent = child;
+                                    } else {
+                                        child = {
+                                            dirPath: path,
+                                            children: [],
+                                            type: 'folder',
+                                            parentId: k-1,
+                                            name: level,
+                                            _id: k
+                                        };
+                                        if(k === array.length -1){
+                                            delete child.children;
+                                            child.type = 'file';
+                                            child.path = params.Bucket + '/' + s3Prefix + path;
+                                        }
+                                        parent.children.push(child);
+                                        parent = child;
+                                    }
+                                });
+
+                                return store;
+                            }
+                            results.forEach((result, index) => {
+                                let pathArray = result.path.split('/').slice(3);
+                                if(pathArray.length === 1) {
+                                    resultStore[pathArray[0]] = {
+                                        type: 'file',
+                                        dirPath: pathArray[0],
+                                        name: pathArray[0],
+                                        path: result.path
+                                    };
+                                } else {
+                                    if(!resultStore[pathArray[0]]) {
+                                        resultStore[pathArray[0]] = {
+                                            type: 'folder',
+                                            children: [],
+                                            name: pathArray[0],
+                                            dirPath: pathArray[0] + '/'
+                                        };
+                                    }
+                                    nestResultsByPath(pathArray, resultStore);
+                                }
+                            });
+
+                            Object.keys(resultStore).forEach((result) => {
+                                formattedResults.push(resultStore[result])
+                            });
+///////////////////////////////////////////////////////////////////////////////////////////
                             c.crn.jobs.updateOne({_id: ObjectID(jobId)}, {
                                 $set:{
                                     'analysis.status': finalStatus,
-                                    results: results,
+                                    results: formattedResults,
                                     'analysis.logstreams': logStreamNames
                                 }
                             });

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -286,7 +286,7 @@ let handlers = {
                                     return childrenArray.find((child) => {
                                         return child.dirPath === path;
                                     });
-                                }
+                                };
 
                                 array.forEach((level, k) => {
                                     //right now setting up top level before passing in store. can probably change this
@@ -321,8 +321,9 @@ let handlers = {
                                 });
 
                                 return store;
-                            }
-                            results.forEach((result, index) => {
+                            };
+
+                            results.forEach((result) => {
                                 let pathArray = result.path.split('/').slice(3);
                                 if(pathArray.length === 1) {
                                     resultStore[pathArray[0]] = {
@@ -345,7 +346,7 @@ let handlers = {
                             });
 
                             Object.keys(resultStore).forEach((result) => {
-                                formattedResults.push(resultStore[result])
+                                formattedResults.push(resultStore[result]);
                             });
 ///////////////////////////////////////////////////////////////////////////////////////////
                             c.crn.jobs.updateOne({_id: ObjectID(jobId)}, {


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/95
* build out results tree to match what was previously being sent back by scitran(?) so folder structure is preserved.  This was needed for both download all results and for results displayed in UI.  
* requires client branch results-tree