### PR TITLE
Job polling

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -16,6 +16,8 @@ import emitter from '../libs/events';
 let c = mongo.collections;
 let events = config.events;
 
+//Job Polling
+
 // handlers ----------------------------------------------------------------
 
 /**


### PR DESCRIPTION
* addresses issue https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/97
* adding server side polling for jobs at a 5 minute interval.  This is intended to continue monitoring job status even if client connection is lost (i.e. client stops polling) and send out notifications when job completes (SUCCEEDED or FAILED)
* Currently server side polling is ONLY concerned with notifications and emitting job complete event for logging purposes.  Client side polling on revisiting app still aggregates results and adds them to mongo object when the client connection is re-established.  @NellH let me know if this approach needs to change.  