### PR TITLE
Add middleware to check number of jobs for non admin users

### DIFF
--- a/libs/auth.js
+++ b/libs/auth.js
@@ -104,6 +104,28 @@ let auth = {
     },
 
     /**
+    * Check to see if user is an admin user. If so, just next()
+    * if not, prevent user from having more than 2 jobs running concurrently
+    * NOTE: this middleware function depends on auth middleware that attaches user and isSuperUser to req having already run
+    */
+    submitJobAccess(req, res, next) {
+        let user = req.user;
+        let admin = !!req.isSuperUser;
+        if(admin) {
+            return next();
+        }
+
+        c.crn.jobs.find({userId: user, 'analysis.status': {$in: ['UPLOADING', 'RUNNING']}}).toArray((err, jobs) => {
+            let totalRunningJobs = jobs.length;
+            if(totalRunningJobs < 2) {
+                return next();
+            }
+
+            return res.status(403).send({error: 'You only have access to run 2 concurrent jobs.'});
+        });
+    },
+
+    /**
      * Ticket
      *
      * Checks for a valid ticket parameter

--- a/routes.js
+++ b/routes.js
@@ -115,6 +115,7 @@ const routes = [
         url: '/datasets/:datasetId/jobs',
         middleware: [
             auth.datasetAccess(),
+            auth.submitJobAccess,
             schema.validateBody(schemas.job.submit)
         ],
         handler: awsJobs.submitJob


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/48
* adding auth middleware to make sure non admins can't run more than 2 concurrent jobs
* requires crn_app branch limit-jobs to display correct error message