### PR TITLE
Divide subtasks/jobs into a maximum of 20 buckets

### DIFF
--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -161,11 +161,12 @@ export default (aws) => {
                 batchJob.parameters.participant_label instanceof Array &&
                 batchJob.parameters.participant_label.length > 0) {
                 let jobs = [];
-                batchJob.parameters.participant_label.forEach((subject) => {
+                let groups = this._partitionLabels(batchJob.parameters.participant_label);
+                groups.forEach((subjectGroup) => {
                     let subjectBatchJob = JSON.parse(JSON.stringify(batchJob));
                     subjectBatchJob.dependsOn = _depsObjects(deps);
-                    // Reduce participant_label to a single subject
-                    subjectBatchJob.parameters.participant_label = [subject];
+                    // Reduce participant_label to a single group of subjects
+                    subjectBatchJob.parameters.participant_label = subjectGroup;
                     this._addJobArguments(subjectBatchJob);
                     delete subjectBatchJob.parameters;
                     jobs.push(job.bind(this, subjectBatchJob));

--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -224,6 +224,26 @@ export default (aws) => {
         },
 
         /**
+         * For now, we limit parallelization to 20 subjobs
+         *
+         * Takes a list of labels and returns a list of no more than 20 lists.
+         */
+        _partitionLabels(labels) {
+            // Limit to 20 groups
+            let pCount = Math.min(20, labels.length);
+            let partitions = new Array(pCount);
+            labels.forEach((label, index) => {
+                let bucket = partitions[index%pCount];
+                if (bucket instanceof Array) {
+                    bucket.push(label);
+                } else {
+                    partitions[index%pCount] = [label];
+                }
+            });
+            return partitions;
+        },
+
+        /**
          * Convert batchJob.parameters to a BIDS_ARGUMENTS environment var
          * and add to document to submit the job
          */

--- a/tests/libs/aws.spec.js
+++ b/tests/libs/aws.spec.js
@@ -40,4 +40,47 @@ describe('libs/aws/batch.js', () => {
             assert.equal(args, '--participant_label 01 02 03 --n_cpus 4');
         });
     });
+    describe('_partitionLabels()', () => {
+        it('should produce 3 expected groupings from 3 labels', () => {
+            let labels = [ ...Array(3).keys() ];
+            assert.deepEqual(aws.batch._partitionLabels(labels), [[0], [1], [2]]);
+        });
+        it('should produce 20 expected groupings from 23 labels', () => {
+            let labels = [ ...Array(23).keys() ];
+            let res = aws.batch._partitionLabels(labels);
+            assert.deepEqual(res, [[0, 20], [1, 21], [2, 22], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15], [16], [17], [18], [19]]);
+        });
+        it('should limit 10 labels to 10 groups', () => {
+            let labels = [ ...Array(10).keys() ];
+            assert.equal(aws.batch._partitionLabels(labels).length, 10);
+        });
+        it('should limit 25 labels to 20 groups', () => {
+            let labels = [ ...Array(25).keys() ];
+            assert.equal(aws.batch._partitionLabels(labels).length, 20);
+        });
+        it('should limit 40 labels to 20 groups', () => {
+            let labels = [ ...Array(40).keys() ];
+            assert.equal(aws.batch._partitionLabels(labels).length, 20);
+        });
+        it('should limit 250 labels to 20 groups', () => {
+            let labels = [ ...Array(250).keys() ];
+            assert.equal(aws.batch._partitionLabels(labels).length, 20);
+        });
+        it('should limit 1 label to 1 group', () => {
+            let labels = [ "0" ];
+            assert.equal(aws.batch._partitionLabels(labels).length, 1);
+        });
+        it('should return 0 groups for 0 labels', () => {
+            let labels = [ ];
+            assert.equal(aws.batch._partitionLabels(labels).length, 0);
+        });
+        it('should partition labels into +/- 1 item size groups', () => {
+            let labels = [ ...Array(250).keys() ];
+            let groups = aws.batch._partitionLabels(labels);
+            let lengths = groups.map((group) => {
+                return group.length;
+            });
+            assert.equal((Math.max(...lengths) - Math.min(...lengths)), 1);
+        });
+    });
 });

--- a/tests/libs/aws.spec.js
+++ b/tests/libs/aws.spec.js
@@ -67,7 +67,7 @@ describe('libs/aws/batch.js', () => {
             assert.equal(aws.batch._partitionLabels(labels).length, 20);
         });
         it('should limit 1 label to 1 group', () => {
-            let labels = [ "0" ];
+            let labels = [ '0' ];
             assert.equal(aws.batch._partitionLabels(labels).length, 1);
         });
         it('should return 0 groups for 0 labels', () => {


### PR DESCRIPTION
This splits the list of participants up into up to 20 groups and submits at most 20 tasks to stay within the limit for maximum dependent jobs on Batch.