### PR TITLE
Server Side Polling

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -189,7 +189,7 @@ let handlers = {
                             } else {
                                 emitter.emit(events.JOB_STARTED, {job: batchJobParams, createdDate: job.analysis.created}, userId);
                                 //server side polling in case client polling stops
-                                handlers._pollJob(mongoJob.insertedId, userId);
+                                // handlers._pollJob(mongoJob.insertedId, userId);
                             }
                         });
                     });
@@ -218,7 +218,7 @@ let handlers = {
             if ((status === 'SUCCEEDED' && job.results && job.results.length > 0) || status === 'FAILED' || status === 'REJECTED' || !jobs || !jobs.length) {
                 res.send(job);
             } else {
-                handlers._getJobStatus(job, userId, (err, data) => {
+                handlers.getJobStatus(job, userId, (err, data) => {
                     if(err) {return next(err);}
                     res.send(data);
                 });
@@ -409,7 +409,7 @@ let handlers = {
                 if(finished) {
                     handlers._jobComplete(clonedJob, userId);
                 } else {
-                    handlers._getJobStatus(job, userId, (err, data) => {
+                    handlers.getJobStatus(job, userId, (err, data) => {
                         if(err) {
                             //failing silently here
                             console.log(err);
@@ -429,7 +429,7 @@ let handlers = {
     /*
      * Gets jobs for a given analysis from batch, checks overall status and callsback with a snapshot of the analysis status
      */
-    _getJobStatus(job, userId, callback) {
+    getJobStatus(job, userId, callback) {
         aws.batch.getAnalysisJobs(job, (err, jobs) => {
             if(err) {return callback(err);}
             //check jobs status

--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -188,8 +188,6 @@ let handlers = {
                                 return;
                             } else {
                                 emitter.emit(events.JOB_STARTED, {job: batchJobParams, createdDate: job.analysis.created}, userId);
-                                //server side polling in case client polling stops
-                                // handlers._pollJob(mongoJob.insertedId, userId);
                             }
                         });
                     });

--- a/libs/mongo.js
+++ b/libs/mongo.js
@@ -49,8 +49,9 @@ export default {
      *
      * Makes a connection to mongodbs and creates an accessible
      * reference to the dbs and collections
+     * takes optional callback (using callback to kick of server side job polling)
      */
-    connect() {
+    connect(callback) {
         async.each(Object.keys(this.dbs), (dbName, cb) => {
             MongoClient.connect(config.mongo.url + dbName, (err, db) => {
                 if (err) {
@@ -67,6 +68,10 @@ export default {
                 }
                 cb();
             });
+        }, function(err) {
+            if(callback && typeof callback === 'function') {
+                callback();
+            }
         });
     }
 };

--- a/libs/mongo.js
+++ b/libs/mongo.js
@@ -68,7 +68,7 @@ export default {
                 }
                 cb();
             });
-        }, function(err) {
+        }, () => {
             if(callback && typeof callback === 'function') {
                 callback();
             }

--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ mongo.connect(() => {
         }).toArray((err, jobs) => {
             async.each(jobs, (job, cb) => {
                 awsJobs.getJobStatus(job, job.userId, cb);
-            }, (err) {
+            }, (err) => {
                 setTimeout(pollJobs, interval);
             });
         });

--- a/server.js
+++ b/server.js
@@ -22,18 +22,10 @@ import events      from './libs/events';
 mongo.connect(() => {
     //Start job polling
     let c = mongo.collections;
-    let interval = let interval = 300000; // 5 minute interval for server side polling
+    let interval = 300000; // 5 minute interval for server side polling
 
     let pollJobs = () => {
-        c.crn.jobs.find({
-            $or: [{
-                'analysis.status':{$ne: 'SUCCEEDED'}
-            } , {
-                'analysis.status':{$ne: 'FAILED'}
-            }, {
-                'analysis.status':{$ne: 'REJECTED'}
-            }]
-        }).toArray((err, jobs) => {
+        c.crn.jobs.find({ 'analysis.status': {$nin: ['SUCCEEDED', 'FAILED', 'REJECTED', 'UPLOADING']}}).toArray((err, jobs) => {
             async.each(jobs, (job, cb) => {
                 awsJobs.getJobStatus(job, job.userId, cb);
             }, (err) => {

--- a/server.js
+++ b/server.js
@@ -24,6 +24,11 @@ mongo.connect(() => {
     let c = mongo.collections;
     let interval = 300000; // 5 minute interval for server side polling
 
+    /**
+     * pollJobs queries mongo to find running jobs and runs getJobStatus to check status and update if needed.
+     * excluding 'UPLOADING' because jobs in that state have not been submitted to Batch
+     * polling occurs on a 5 minute interval
+     */
     let pollJobs = () => {
         c.crn.jobs.find({ 'analysis.status': {$nin: ['SUCCEEDED', 'FAILED', 'REJECTED', 'UPLOADING']}}).toArray((err, jobs) => {
             async.each(jobs, (job, cb) => {


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/119
* moved server side job polling from submitJob method in aws jobs to server start. This fixes issue where a server crash results in a no polling on restart.