### PR TITLE
Adds single quotes to bids arguments with spaces

### DIFF
--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -249,12 +249,23 @@ export default (aws) => {
                 }
             }).map((key) => {
                 let argument = '--' + key + ' ';
-                let value = parameters[key];
+                let value = typeof parameters[key] === 'string' ? this._formatString(parameters[key]) : parameters[key];
                 if (value instanceof Array) {
-                    value = value.join(' ');
+                    value = value.map((item)=> {
+                        return typeof item === 'string' ? this._formatString(item) : item;
+                    }).join(' ');
                 }
                 return argument.concat(value);
             }).join(' ');
+        },
+
+        /**
+         * If a string argument has any whitespace we need to make sure that we single quote it.
+         * Accepts a string and returns an appropriately formated string
+         */
+        _formatString(str) {
+            let hasSpace = /\s/g.test(str);
+            return (hasSpace ?  "'" + str + "'" : str);
         },
 
         /**

--- a/libs/aws/batch.js
+++ b/libs/aws/batch.js
@@ -265,7 +265,7 @@ export default (aws) => {
          */
         _formatString(str) {
             let hasSpace = /\s/g.test(str);
-            return (hasSpace ?  "'" + str + "'" : str);
+            return (hasSpace ?  '\'' + str + '\'' : str);
         },
 
         /**

--- a/tests/libs/aws.spec.js
+++ b/tests/libs/aws.spec.js
@@ -6,7 +6,7 @@ const nCpusParam = {n_cpus: 4};
 const templateNameParam = {template_name: 'template1'};
 const emptyParam = {template_name: []};
 const nullParam = {template_name: null};
-const spaceParam = {license_key: "Super Secret Shhhhhh"};
+const spaceParam = {license_key: 'Super Secret Shhhhhh', cartoons: ['Ren and Stimpy']};
 
 describe('libs/aws/batch.js', () => {
     describe('_prepareArguments()', () => {
@@ -43,7 +43,7 @@ describe('libs/aws/batch.js', () => {
         it('should properly format string arguments with spaces', () => {
             let params = Object.assign({}, subjectParam, spaceParam);
             let args = aws.batch._prepareArguments(params);
-            assert.equal(args, '--participant_label 01 02 03 --license_key \'Super Secret Shhhhhh\'');
+            assert.equal(args, '--participant_label 01 02 03 --license_key \'Super Secret Shhhhhh\' --cartoons \'Ren and Stimpy\'');
         });
     });
     describe('_partitionLabels()', () => {

--- a/tests/libs/aws.spec.js
+++ b/tests/libs/aws.spec.js
@@ -6,6 +6,7 @@ const nCpusParam = {n_cpus: 4};
 const templateNameParam = {template_name: 'template1'};
 const emptyParam = {template_name: []};
 const nullParam = {template_name: null};
+const spaceParam = {license_key: "Super Secret Shhhhhh"};
 
 describe('libs/aws/batch.js', () => {
     describe('_prepareArguments()', () => {
@@ -38,6 +39,11 @@ describe('libs/aws/batch.js', () => {
             let params = Object.assign({}, subjectParam, nCpusParam, nullParam);
             let args = aws.batch._prepareArguments(params);
             assert.equal(args, '--participant_label 01 02 03 --n_cpus 4');
+        });
+        it('should properly format string arguments with spaces', () => {
+            let params = Object.assign({}, subjectParam, spaceParam);
+            let args = aws.batch._prepareArguments(params);
+            assert.equal(args, '--participant_label 01 02 03 --license_key \'Super Secret Shhhhhh\'');
         });
     });
     describe('_partitionLabels()', () => {


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/138
* checks to see whether string arguments have spaces and wraps them in single quotes if they do.
* added some tests for this as well.

NOTE: I only tested this with the unit test in this repo.  would be useful to do a 'real world' test with an app that takes args with spaces.