### PR TITLE
Rejected Jobs Notifications

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,6 +32,7 @@ mongo.connect(() => {
     let pollJobs = () => {
         c.crn.jobs.find({ 'analysis.status': {$nin: ['SUCCEEDED', 'FAILED', 'UPLOADING']}}).toArray((err, jobs) => {
             async.each(jobs, (job, cb) => {
+                // handling rejected jobs here so we can send notifications for those jobs
                 if(job.analysis.status === 'REJECTED') {
                     awsJobs.jobComplete(job, job.userId, cb);
                 } else {

--- a/server.js
+++ b/server.js
@@ -30,9 +30,13 @@ mongo.connect(() => {
      * polling occurs on a 5 minute interval
      */
     let pollJobs = () => {
-        c.crn.jobs.find({ 'analysis.status': {$nin: ['SUCCEEDED', 'FAILED', 'REJECTED', 'UPLOADING']}}).toArray((err, jobs) => {
+        c.crn.jobs.find({ 'analysis.status': {$nin: ['SUCCEEDED', 'FAILED', 'UPLOADING']}}).toArray((err, jobs) => {
             async.each(jobs, (job, cb) => {
-                awsJobs.getJobStatus(job, job.userId, cb);
+                if(job.analysis.status === 'REJECTED') {
+                    awsJobs.jobComplete(job, job.userId, cb);
+                } else {
+                    awsJobs.getJobStatus(job, job.userId, cb);
+                }
             }, (err) => {
                 setTimeout(pollJobs, interval);
             });


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/156
* adding email notifications to server side polling.  We are currently not handling these during client side polling because that polling requires jobs to have "started" on batch.
* NOTE.  when this gets merged, folks will get emails for ALL of their rejected jobs that are in the db.