### PR TITLE
Return aws batch statuses for each job in an analysis

### DIFF
--- a/handlers/awsJobs.js
+++ b/handlers/awsJobs.js
@@ -395,6 +395,18 @@ let handlers = {
             let statusArray = jobs.map((job) => {
                 return job.status;
             });
+
+            let batchStatus = jobs.map((job) => {
+                return {
+                    status: job.status,
+                    job: job.jobId
+                };
+            }).sort((a,b) => {
+                return (a.job.split('-')[0] > b.job.split('-')[0]) ? 1 : -1;
+            });
+
+            analysis.batchStatus = batchStatus;
+
             let finished = handlers._checkJobStatus(statusArray);
 
             analysis.status = !finished ? 'RUNNING' : 'FINALIZING';


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/openneuro/issues/168 and https://gitlab.sqm.io/stanford_crn/openneuro/issues/197
* returning the batch status of each job in an analysis to client so they can be displayed during analysis running state.

requires client branch of same name job-latest-status